### PR TITLE
fix: pass application context to receive adapter

### DIFF
--- a/cmd/receive_adapter/main.go
+++ b/cmd/receive_adapter/main.go
@@ -27,5 +27,5 @@ func main() {
 	ctx := signals.NewContext()
 	ctx = adapter.WithInjectorEnabled(ctx)
 
-	adapter.Main("cephsource", cephadapter.NewEnvConfig, cephadapter.NewAdapter)
+	adapter.MainWithContext(ctx, "cephsource", cephadapter.NewEnvConfig, cephadapter.NewAdapter)
 }

--- a/cmd/receive_adapter/main.go
+++ b/cmd/receive_adapter/main.go
@@ -18,10 +18,14 @@ package main
 
 import (
 	"knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/signals"
 
 	cephadapter "knative.dev/eventing-ceph/pkg/adapter"
 )
 
 func main() {
+	ctx := signals.NewContext()
+	ctx = adapter.WithInjectorEnabled(ctx)
+
 	adapter.Main("cephsource", cephadapter.NewEnvConfig, cephadapter.NewAdapter)
 }


### PR DESCRIPTION
Fixes the receive adapter main function so it doesn't panic on start
